### PR TITLE
146 feature allow both keycloak and scicat user jwt tokens

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -171,6 +171,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: astral-sh/ruff-action@v3
+        with:
+          version: 0.8.0
+          args: "format --check"
+          src: ./backend/api
+
       - name: Log into registry ${{ env.REGISTRY }}
         # if: github.event_name != 'pull_request'
         uses: docker/login-action@v3

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -171,10 +171,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: astral-sh/ruff-action@v3
+      - name: Ruff Format
+        uses: astral-sh/ruff-action@v3
         with:
           version: 0.8.0
           args: "format --check"
+          src: ./backend/api
+
+      - name: Ruff Check
+        uses: astral-sh/ruff-action@v3
+        with:
+          version: 0.8.0
+          args: "check"
           src: ./backend/api
 
       - name: Log into registry ${{ env.REGISTRY }}

--- a/backend/api/.flake8
+++ b/backend/api/.flake8
@@ -1,3 +1,0 @@
-[flake8]
-max-line-length = 130
-exclude = .git,__pycache__,__init__.py,.mypy_cache,.pytest_cache,.venv

--- a/backend/api/openapi.yaml
+++ b/backend/api/openapi.yaml
@@ -10,6 +10,8 @@ security:
 paths:
   /token:
     post:
+      security:
+        - SciCatAuth: []
       operationId: create_new_service_token
       responses:
         "201":
@@ -190,7 +192,11 @@ paths:
         - presignedUrls
 components:
   securitySchemes:
-    BearerAuth: # arbitrary name for the security scheme
+    BearerAuth: # RS256 tokens signed by Keycloak
+      type: http
+      scheme: bearer
+      bearerFormat: JWT # optional, but indicates the format of the token
+    SciCatAuth: # HS256 tokens signed by SciCat
       type: http
       scheme: bearer
       bearerFormat: JWT # optional, but indicates the format of the token

--- a/backend/api/pyproject.toml
+++ b/backend/api/pyproject.toml
@@ -49,7 +49,7 @@ exclude = [
     "./src/openapi_server/apis/",
     "./src/openapi_server/models/",
 ]
-line-length = 130
+line-length = 110
 indent-width = 4
 
 [[tool.uv.index]]

--- a/backend/api/pyproject.toml
+++ b/backend/api/pyproject.toml
@@ -48,6 +48,8 @@ exclude = [
     "venv",
     "./src/openapi_server/apis/",
     "./src/openapi_server/models/",
+    "./src/openapi_server/tests/",
+    "./tests/",
 ]
 line-length = 110
 indent-width = 4

--- a/backend/api/src/openapi_server/__main__.py
+++ b/backend/api/src/openapi_server/__main__.py
@@ -32,14 +32,15 @@ app = FastAPI(
 
 settings = Settings()
 
+
 class Enforce201Middleware(BaseHTTPMiddleware):
     async def dispatch(self, request, call_next):
         response = await call_next(request)
-        
+
         # Ensure POST /token returns 201
         if request.method == "POST" and response.status_code == 200:
             response.status_code = 201
-        
+
         return response
 
 
@@ -59,14 +60,11 @@ if __name__ == "__main__":
         allow_methods=["*"],
         allow_headers=["*"],
     )
-    app.add_middleware(
-        Enforce201Middleware
-    )
+    app.add_middleware(Enforce201Middleware)
 
     app.include_router(ArchivingApiRouter)
     app.include_router(PresignedUrlsApiRouter)
     app.include_router(ServiceTokenRouter)
-
 
     uvi_config = uvicorn.Config(
         app,
@@ -81,9 +79,7 @@ if __name__ == "__main__":
     # TODO: for testing purposes only. To be removed later.
     token = generate_token()
     if token:
-        _LOGGER.info(
-            f"Test Bearer token: {token.get('access_token', 'No access_token found')}"
-        )
+        _LOGGER.info(f"Test Bearer token: {token.get('access_token', 'No access_token found')}")
 
     server = uvicorn.Server(uvi_config)
     server.run()

--- a/backend/api/src/openapi_server/apis/service_token_api.py
+++ b/backend/api/src/openapi_server/apis/service_token_api.py
@@ -26,7 +26,7 @@ from openapi_server.models.extra_models import TokenModel  # noqa: F401
 from openapi_server.models.create_service_token_resp import CreateServiceTokenResp
 from openapi_server.models.http_validation_error import HTTPValidationError
 from openapi_server.models.internal_error import InternalError
-from openapi_server.security_api import get_token_BearerAuth
+from openapi_server.security_api import get_token_SciCatAuth
 
 router = APIRouter()
 
@@ -47,8 +47,8 @@ for _, name, _ in pkgutil.iter_modules(ns_pkg.__path__, ns_pkg.__name__ + "."):
     response_model_by_alias=True,
 )
 async def create_new_service_token(
-    token_BearerAuth: TokenModel = Security(
-        get_token_BearerAuth
+    token_SciCatAuth: TokenModel = Security(
+        get_token_SciCatAuth
     ),
 ) -> CreateServiceTokenResp:
     if not BaseServiceTokenApi.subclasses:

--- a/backend/api/src/openapi_server/apis/service_token_api_base.py
+++ b/backend/api/src/openapi_server/apis/service_token_api_base.py
@@ -5,7 +5,7 @@ from typing import ClassVar, Dict, List, Tuple  # noqa: F401
 from openapi_server.models.create_service_token_resp import CreateServiceTokenResp
 from openapi_server.models.http_validation_error import HTTPValidationError
 from openapi_server.models.internal_error import InternalError
-from openapi_server.security_api import get_token_BearerAuth
+from openapi_server.security_api import get_token_SciCatAuth
 
 class BaseServiceTokenApi:
     subclasses: ClassVar[Tuple] = ()

--- a/backend/api/src/openapi_server/impl/archiving.py
+++ b/backend/api/src/openapi_server/impl/archiving.py
@@ -1,7 +1,6 @@
 from typing import List
 from uuid import UUID
 from prefect.client.schemas.objects import FlowRun
-from prefect import flow  # required do to https://github.com/PrefectHQ/prefect/issues/16105
 from prefect.deployments import run_deployment
 
 

--- a/backend/api/src/openapi_server/impl/archiving.py
+++ b/backend/api/src/openapi_server/impl/archiving.py
@@ -23,13 +23,17 @@ async def run_create_dataset_deployment(
 
 async def run_archiving_deployment(job_id: UUID, dataset_list: List[str]):
     a = await run_deployment(
-        "archive_datasetlist/datasets_archival", parameters={"dataset_ids": dataset_list, "job_id": job_id}, timeout=0
+        "archive_datasetlist/datasets_archival",
+        parameters={"dataset_ids": dataset_list, "job_id": job_id},
+        timeout=0,
     )  # type: ignore
     return a
 
 
 async def run_retrieval_deployment(job_id: UUID, dataset_list: List[str]):
     a = await run_deployment(
-        "retrieve_datasetlist/datasets_retrieval", parameters={"dataset_ids": dataset_list, "job_id": job_id}, timeout=0
+        "retrieve_datasetlist/datasets_retrieval",
+        parameters={"dataset_ids": dataset_list, "job_id": job_id},
+        timeout=0,
     )  # type: ignore
     return a

--- a/backend/api/src/openapi_server/impl/archving_api_impl.py
+++ b/backend/api/src/openapi_server/impl/archving_api_impl.py
@@ -36,11 +36,15 @@ class BaseArchivingApiImpl(BaseArchivingApi):
                 dataset_id=data_set_id,
             )
 
-            _LOGGER.debug("Flow run for dataset % created. Id=%d Name=%s", data_set_id, flowRun.id, flowRun.name)
+            _LOGGER.debug(
+                "Flow run for dataset % created. Id=%d Name=%s", data_set_id, flowRun.id, flowRun.name
+            )
             return CreateDatasetResp(Name=flowRun.name, Uuid=str(flowRun.id), DataSetId=data_set_id)
         except Exception as e:
             _LOGGER.error(e)
-            return JSONResponse(status_code=500, content={"message": "Failed to create new dataset", "details": str(e)})
+            return JSONResponse(
+                status_code=500, content={"message": "Failed to create new dataset", "details": str(e)}
+            )
 
     async def create_job(
         self,
@@ -50,7 +54,9 @@ class BaseArchivingApiImpl(BaseArchivingApi):
             job_id = UUID(create_job_body.id)
         except ValueError as e:
             _LOGGER.warning(e)
-            return JSONResponse(status_code=422, content={"message": "Failed to create job", "details": str(e)})
+            return JSONResponse(
+                status_code=422, content={"message": "Failed to create job", "details": str(e)}
+            )
 
         try:
             match create_job_body.type:
@@ -61,8 +67,12 @@ class BaseArchivingApiImpl(BaseArchivingApi):
                 case _:
                     return JSONResponse(status_code=500, content={"message": f"unknown job type {type}"})
 
-            _LOGGER.debug("Flow run for job %s created. Id=%d Name=%s", create_job_body.id, flowRun.id, flowRun.name)
+            _LOGGER.debug(
+                "Flow run for job %s created. Id=%d Name=%s", create_job_body.id, flowRun.id, flowRun.name
+            )
             return CreateJobResp(Uuid=str(flowRun.id), Name=flowRun.name)
         except Exception as e:
             _LOGGER.error(e)
-            return JSONResponse(status_code=500, content={"message": "Failed to create job", "details": str(e)})
+            return JSONResponse(
+                status_code=500, content={"message": "Failed to create job", "details": str(e)}
+            )

--- a/backend/api/src/openapi_server/impl/archving_api_impl.py
+++ b/backend/api/src/openapi_server/impl/archving_api_impl.py
@@ -1,9 +1,4 @@
-import base64
-from typing import Any, List, Optional
-
-from fastapi import Body, HTTPException, Header, Query
 from fastapi.responses import JSONResponse
-from pydantic import StrictInt, StrictStr
 from uuid import UUID
 
 from openapi_server.apis.archiving_api_base import BaseArchivingApi
@@ -11,7 +6,6 @@ from openapi_server.models.create_dataset_body import CreateDatasetBody
 from openapi_server.models.create_dataset_resp import CreateDatasetResp
 from openapi_server.models.create_job_body import CreateJobBody
 from openapi_server.models.create_job_resp import CreateJobResp
-from openapi_server.models.internal_error import InternalError
 
 from .archiving import run_create_dataset_deployment, run_archiving_deployment, run_retrieval_deployment
 

--- a/backend/api/src/openapi_server/impl/presigned_url_impl.py
+++ b/backend/api/src/openapi_server/impl/presigned_url_impl.py
@@ -6,7 +6,6 @@ from openapi_server.models.complete_upload_body import CompleteUploadBody
 from openapi_server.models.complete_upload_resp import CompleteUploadResp
 from openapi_server.models.abort_upload_body import AbortUploadBody
 from openapi_server.models.abort_upload_resp import AbortUploadResp
-from openapi_server.models.internal_error import InternalError
 from openapi_server.models.presigned_url_body import PresignedUrlBody
 from openapi_server.models.presigned_url_resp import PresignedUrlResp
 

--- a/backend/api/src/openapi_server/impl/presigned_url_impl.py
+++ b/backend/api/src/openapi_server/impl/presigned_url_impl.py
@@ -13,7 +13,12 @@ from openapi_server.models.presigned_url_resp import PresignedUrlResp
 from openapi_server.apis.presigned_urls_api_base import BasePresignedUrlsApi
 from openapi_server.settings import Settings
 
-from .s3 import complete_multipart_upload, abort_multipart_upload, create_presigned_url, create_presigned_urls_multipart
+from .s3 import (
+    complete_multipart_upload,
+    abort_multipart_upload,
+    create_presigned_url,
+    create_presigned_urls_multipart,
+)
 
 from logging import getLogger
 
@@ -31,7 +36,9 @@ class BasePresignedUrlsApiImpl(BasePresignedUrlsApi):
             return complete_multipart_upload(_SETTINGS.MINIO_LANDINGZONE_BUCKET, complete_upload_body)
         except Exception as e:
             _LOGGER.error(str(e))
-            return JSONResponse(status_code=500, content={"message": "Failed to complete upload", "details": str(e)})
+            return JSONResponse(
+                status_code=500, content={"message": "Failed to complete upload", "details": str(e)}
+            )
 
     async def abort_multipart_upload(
         self,
@@ -50,7 +57,9 @@ class BasePresignedUrlsApiImpl(BasePresignedUrlsApi):
             )
         except Exception as e:
             _LOGGER.error(str(e))
-            return JSONResponse(status_code=500, content={"message": "Failed to abort multipart upload", "details": str(e)})
+            return JSONResponse(
+                status_code=500, content={"message": "Failed to abort multipart upload", "details": str(e)}
+            )
 
     async def get_presigned_urls(
         self,
@@ -75,4 +84,6 @@ class BasePresignedUrlsApiImpl(BasePresignedUrlsApi):
                 return PresignedUrlResp(UploadID=uploadId, Urls=b64urls)
         except Exception as e:
             _LOGGER.error(str(e))
-            return JSONResponse(status_code=500, content={"message": "Failed to get presigned urls", "details": str(e)})
+            return JSONResponse(
+                status_code=500, content={"message": "Failed to get presigned urls", "details": str(e)}
+            )

--- a/backend/api/src/openapi_server/impl/s3.py
+++ b/backend/api/src/openapi_server/impl/s3.py
@@ -39,10 +39,14 @@ def create_presigned_url(bucket_name, object_name) -> str:
         raise e
 
 
-def create_presigned_urls_multipart(bucket_name, object_name, part_count) -> tuple[str, List[tuple[int, str]]]:
+def create_presigned_urls_multipart(
+    bucket_name, object_name, part_count
+) -> tuple[str, List[tuple[int, str]]]:
     # Create a multipart upload
     try:
-        response = s3_client.create_multipart_upload(Bucket=bucket_name, Key=object_name, ChecksumAlgorithm="SHA256")
+        response = s3_client.create_multipart_upload(
+            Bucket=bucket_name, Key=object_name, ChecksumAlgorithm="SHA256"
+        )
         upload_id = response["UploadId"]
         _LOGGER.info(f"Upload ID: {upload_id}")
     except ClientError as e:
@@ -55,7 +59,12 @@ def create_presigned_urls_multipart(bucket_name, object_name, part_count) -> tup
         try:
             presigned_url = s3_client.generate_presigned_url(
                 "upload_part",
-                Params={"Bucket": bucket_name, "Key": object_name, "UploadId": upload_id, "PartNumber": part_number},
+                Params={
+                    "Bucket": bucket_name,
+                    "Key": object_name,
+                    "UploadId": upload_id,
+                    "PartNumber": part_number,
+                },
                 HttpMethod="PUT",
                 ExpiresIn=_SETTINGS.URL_EXPIRATION_SECONDS,
             )

--- a/backend/api/src/openapi_server/impl/service_token_impl.py
+++ b/backend/api/src/openapi_server/impl/service_token_impl.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from openapi_server.models.create_service_token_resp import CreateServiceTokenResp
 
 from openapi_server.apis.service_token_api_base import BaseServiceTokenApi

--- a/backend/api/src/openapi_server/models/create_service_token_resp.py
+++ b/backend/api/src/openapi_server/models/create_service_token_resp.py
@@ -36,9 +36,9 @@ class CreateServiceTokenResp(BaseModel):
     refresh_token: StrictStr = Field(description="The JWT refresh token")
     refresh_expires_in: Optional[StrictInt] = Field(default=None, description="The duration in seconds the refresh token is valid for")
     token_type: Optional[StrictStr] = Field(default=None, description="Bearer")
-    not_before_policy: Optional[StrictInt] = Field(default=None, description="timestamp that indicates the time before which the JWT must not be accepted for processing", alias="not-before-policy")
-    session_state: Optional[StrictStr] = None
-    scope: Optional[StrictStr] = Field(default=None, description="claim in a JWT defines the set of permissions or access rights granted")
+    not_before_policy: Optional[StrictInt] = Field(default=None, description="Timestamp that indicates the time before which the JWT must not be accepted for processing", alias="not-before-policy")
+    session_state: Optional[StrictStr] = Field(default=None, description="Session ID, identifier that uniquely ties the session to the authenticated user")
+    scope: Optional[StrictStr] = Field(default=None, description="Claim in a JWT defines the set of permissions or access rights granted")
     __properties: ClassVar[List[str]] = ["access_token", "expires_in", "refresh_token", "refresh_expires_in", "token_type", "not-before-policy", "session_state", "scope"]
 
     model_config = {

--- a/backend/api/src/openapi_server/security_api.py
+++ b/backend/api/src/openapi_server/security_api.py
@@ -84,7 +84,7 @@ def validate_token(token: str, fallback_validator=None) -> dict:
         if not fallback_validator:
             _LOGGER.error(detail)
             raise HTTPException(status_code=401, detail=detail)
-        
+
         # we assume we got a SciCat token, not a token from Keycloak
         if fallback_validator(token):
             return {}, None
@@ -143,9 +143,7 @@ def generate_token() -> dict:
             timeout=5,
         )
     except requests.exceptions.Timeout:
-        _LOGGER.error(
-            f"Error requesting test-token. Could not reach {settings.IDP_URL} because of timeout"
-        )
+        _LOGGER.error(f"Error requesting test-token. Could not reach {settings.IDP_URL} because of timeout")
         return
     except requests.exceptions.RequestException as e:
         _LOGGER.error(f"Error requesting test-token: {e}")
@@ -157,8 +155,9 @@ def generate_token() -> dict:
     else:
         _LOGGER.error("Failed to get token:", response.status_code, response.text)
 
+
 def get_token_SciCatAuth(
-   credentials: HTTPAuthorizationCredentials = Security(security), 
+    credentials: HTTPAuthorizationCredentials = Security(security),
 ):
     if not credentials:
         raise HTTPException(
@@ -169,15 +168,11 @@ def get_token_SciCatAuth(
     payload = validate_token(token, check_scicat_token)
     return payload
 
+
 def get_scicat_user_info(token) -> dict:
     try:
-        headers = {
-            "Authorization": f"Bearer {token}"
-        }
-        response = requests.get(
-            f"{settings.SCICAT_API}/users/my/identity",
-            headers=headers
-        )
+        headers = {"Authorization": f"Bearer {token}"}
+        response = requests.get(f"{settings.SCICAT_API}/users/my/identity", headers=headers)
         response.raise_for_status()
 
     except requests.exceptions.RequestException as e:
@@ -186,7 +181,8 @@ def get_scicat_user_info(token) -> dict:
         raise HTTPException(status_code=401, detail=detail) from e
     return response.json()
 
-def check_scicat_token(token)-> bool:
+
+def check_scicat_token(token) -> bool:
     scicat_userinfo = get_scicat_user_info(token)
     try:
         groups = scicat_userinfo["profile"]["accessGroups"]
@@ -202,6 +198,3 @@ def check_scicat_token(token)-> bool:
         # return False
         raise HTTPException(status_code=401, detail=detail) from e
     return True
-        
-        
-    

--- a/backend/api/src/openapi_server/settings.py
+++ b/backend/api/src/openapi_server/settings.py
@@ -1,6 +1,6 @@
 import os
 from pydantic_settings import BaseSettings
-from pydantic import Field, SecretStr
+from pydantic import SecretStr
 
 
 class Settings(BaseSettings):

--- a/backend/api/src/openapi_server/settings.py
+++ b/backend/api/src/openapi_server/settings.py
@@ -25,5 +25,7 @@ class Settings(BaseSettings):
     IDP_CLIENT_SECRET: SecretStr
     IDP_ALGORITHM: str = "RS256"
 
+    SCICAT_API: str = "https://scopem-openem.ethz.ch/scicat/backend/api/v3"
+
     class Config:
         secrets_dir = os.environ.get("SECRETS_DIR", "/run/secrets")

--- a/backend/api/src/openapi_server/tests/test_archiving_api.py
+++ b/backend/api/src/openapi_server/tests/test_archiving_api.py
@@ -14,19 +14,18 @@ def test_create_new_dataset_new_dataset_post(client: TestClient):
 
     Create New Dataset
     """
-    params = [("file_size_mb", 10),     ("num_files", 10),     ("datablock_size_mb", 20)]
-    headers = {
-    }
+    params = [("file_size_mb", 10), ("num_files", 10), ("datablock_size_mb", 20)]
+    headers = {}
     # uncomment below to make a request
-    #response = client.request(
+    # response = client.request(
     #    "POST",
     #    "/new_dataset/",
     #    headers=headers,
     #    params=params,
-    #)
+    # )
 
     # uncomment below to assert the status code of the HTTP response
-    #assert response.status_code == 200
+    # assert response.status_code == 200
 
 
 def test_get_archivable_objects_archivable_objects_get(client: TestClient):
@@ -35,17 +34,16 @@ def test_get_archivable_objects_archivable_objects_get(client: TestClient):
     Get Archivable Objects
     """
 
-    headers = {
-    }
+    headers = {}
     # uncomment below to make a request
-    #response = client.request(
+    # response = client.request(
     #    "GET",
     #    "/archivable_objects",
     #    headers=headers,
-    #)
+    # )
 
     # uncomment below to assert the status code of the HTTP response
-    #assert response.status_code == 200
+    # assert response.status_code == 200
 
 
 def test_get_retrievable_objects_retrievable_objects_get(client: TestClient):
@@ -54,17 +52,16 @@ def test_get_retrievable_objects_retrievable_objects_get(client: TestClient):
     Get Retrievable Objects
     """
 
-    headers = {
-    }
+    headers = {}
     # uncomment below to make a request
-    #response = client.request(
+    # response = client.request(
     #    "GET",
     #    "/retrievable_objects",
     #    headers=headers,
-    #)
+    # )
 
     # uncomment below to assert the status code of the HTTP response
-    #assert response.status_code == 200
+    # assert response.status_code == 200
 
 
 def test_job_created_jobs_post(client: TestClient):
@@ -75,16 +72,15 @@ def test_job_created_jobs_post(client: TestClient):
     body = None
 
     headers = {
-        "storage_volume": 'storage_volume_example',
+        "storage_volume": "storage_volume_example",
     }
     # uncomment below to make a request
-    #response = client.request(
+    # response = client.request(
     #    "POST",
     #    "/jobs/",
     #    headers=headers,
     #    json=body,
-    #)
+    # )
 
     # uncomment below to assert the status code of the HTTP response
-    #assert response.status_code == 200
-
+    # assert response.status_code == 200

--- a/backend/api/src/openapi_server/tests/test_presigned_urls_api.py
+++ b/backend/api/src/openapi_server/tests/test_presigned_urls_api.py
@@ -16,20 +16,19 @@ def test_abort_multipart_upload_abort_multipart_upload_post(client: TestClient):
 
     Abort Multipart Upload
     """
-    abort_upload_body = {"upload_id":"UploadID","object_name":"ObjectName"}
+    abort_upload_body = {"upload_id": "UploadID", "object_name": "ObjectName"}
 
-    headers = {
-    }
+    headers = {}
     # uncomment below to make a request
-    #response = client.request(
+    # response = client.request(
     #    "POST",
     #    "/abortMultipartUpload",
     #    headers=headers,
     #    json=abort_upload_body,
-    #)
+    # )
 
     # uncomment below to assert the status code of the HTTP response
-    #assert response.status_code == 200
+    # assert response.status_code == 200
 
 
 def test_complete_upload_complete_upload_post(client: TestClient):
@@ -37,20 +36,27 @@ def test_complete_upload_complete_upload_post(client: TestClient):
 
     Complete Upload
     """
-    complete_upload_body = {"parts":[{"part_number":0,"e_tag":"ETag","checksum_sha256":"ChecksumSHA256"},{"part_number":0,"e_tag":"ETag","checksum_sha256":"ChecksumSHA256"}],"upload_id":"UploadID","object_name":"ObjectName","checksum_sha256":"ChecksumSHA256"}
-
-    headers = {
+    complete_upload_body = {
+        "parts": [
+            {"part_number": 0, "e_tag": "ETag", "checksum_sha256": "ChecksumSHA256"},
+            {"part_number": 0, "e_tag": "ETag", "checksum_sha256": "ChecksumSHA256"},
+        ],
+        "upload_id": "UploadID",
+        "object_name": "ObjectName",
+        "checksum_sha256": "ChecksumSHA256",
     }
+
+    headers = {}
     # uncomment below to make a request
-    #response = client.request(
+    # response = client.request(
     #    "POST",
     #    "/completeUpload",
     #    headers=headers,
     #    json=complete_upload_body,
-    #)
+    # )
 
     # uncomment below to assert the status code of the HTTP response
-    #assert response.status_code == 200
+    # assert response.status_code == 200
 
 
 def test_get_presigned_urls_presigned_urls_post(client: TestClient):
@@ -58,18 +64,16 @@ def test_get_presigned_urls_presigned_urls_post(client: TestClient):
 
     Get Presigned Urls
     """
-    presigned_url_body = {"parts":0,"object_name":"ObjectName"}
+    presigned_url_body = {"parts": 0, "object_name": "ObjectName"}
 
-    headers = {
-    }
+    headers = {}
     # uncomment below to make a request
-    #response = client.request(
+    # response = client.request(
     #    "POST",
     #    "/presignedUrls",
     #    headers=headers,
     #    json=presigned_url_body,
-    #)
+    # )
 
     # uncomment below to assert the status code of the HTTP response
-    #assert response.status_code == 200
-
+    # assert response.status_code == 200

--- a/backend/api/tests/test_archiving_api.py
+++ b/backend/api/tests/test_archiving_api.py
@@ -16,20 +16,19 @@ def test_create_job(client: TestClient):
 
     Job Created
     """
-    create_job_body = {"type":"archive","id":"046b6c7f-0b8a-43b9-b35d-6489e6daee91"}
+    create_job_body = {"type": "archive", "id": "046b6c7f-0b8a-43b9-b35d-6489e6daee91"}
 
-    headers = {
-    }
+    headers = {}
     # uncomment below to make a request
-    #response = client.request(
+    # response = client.request(
     #    "POST",
     #    "/jobs/",
     #    headers=headers,
     #    json=create_job_body,
-    #)
+    # )
 
     # uncomment below to assert the status code of the HTTP response
-    #assert response.status_code == 200
+    # assert response.status_code == 200
 
 
 def test_create_new_dataset(client: TestClient):
@@ -37,18 +36,16 @@ def test_create_new_dataset(client: TestClient):
 
     Create New Dataset
     """
-    create_dataset_body = {"file_size_in_mb":40,"number_of_files":20,"datablock_size_in_mb":400}
+    create_dataset_body = {"file_size_in_mb": 40, "number_of_files": 20, "datablock_size_in_mb": 400}
 
-    headers = {
-    }
+    headers = {}
     # uncomment below to make a request
-    #response = client.request(
+    # response = client.request(
     #    "POST",
     #    "/new_dataset/",
     #    headers=headers,
     #    json=create_dataset_body,
-    #)
+    # )
 
     # uncomment below to assert the status code of the HTTP response
-    #assert response.status_code == 200
-
+    # assert response.status_code == 200

--- a/backend/api/tests/test_presigned_urls_api.py
+++ b/backend/api/tests/test_presigned_urls_api.py
@@ -18,20 +18,19 @@ def test_abort_multipart_upload(client: TestClient):
 
     Abort Multipart Upload
     """
-    abort_upload_body = {"upload_id":"UploadID","object_name":"ObjectName"}
+    abort_upload_body = {"upload_id": "UploadID", "object_name": "ObjectName"}
 
-    headers = {
-    }
+    headers = {}
     # uncomment below to make a request
-    #response = client.request(
+    # response = client.request(
     #    "POST",
     #    "/abortMultipartUpload",
     #    headers=headers,
     #    json=abort_upload_body,
-    #)
+    # )
 
     # uncomment below to assert the status code of the HTTP response
-    #assert response.status_code == 200
+    # assert response.status_code == 200
 
 
 def test_complete_upload(client: TestClient):
@@ -39,20 +38,27 @@ def test_complete_upload(client: TestClient):
 
     Complete Upload
     """
-    complete_upload_body = {"parts":[{"part_number":0,"e_tag":"ETag","checksum_sha256":"ChecksumSHA256"},{"part_number":0,"e_tag":"ETag","checksum_sha256":"ChecksumSHA256"}],"upload_id":"UploadID","object_name":"ObjectName","checksum_sha256":"ChecksumSHA256"}
-
-    headers = {
+    complete_upload_body = {
+        "parts": [
+            {"part_number": 0, "e_tag": "ETag", "checksum_sha256": "ChecksumSHA256"},
+            {"part_number": 0, "e_tag": "ETag", "checksum_sha256": "ChecksumSHA256"},
+        ],
+        "upload_id": "UploadID",
+        "object_name": "ObjectName",
+        "checksum_sha256": "ChecksumSHA256",
     }
+
+    headers = {}
     # uncomment below to make a request
-    #response = client.request(
+    # response = client.request(
     #    "POST",
     #    "/completeUpload",
     #    headers=headers,
     #    json=complete_upload_body,
-    #)
+    # )
 
     # uncomment below to assert the status code of the HTTP response
-    #assert response.status_code == 200
+    # assert response.status_code == 200
 
 
 def test_get_presigned_urls(client: TestClient):
@@ -60,18 +66,16 @@ def test_get_presigned_urls(client: TestClient):
 
     Get Presigned Urls
     """
-    presigned_url_body = {"parts":0,"object_name":"ObjectName"}
+    presigned_url_body = {"parts": 0, "object_name": "ObjectName"}
 
-    headers = {
-    }
+    headers = {}
     # uncomment below to make a request
-    #response = client.request(
+    # response = client.request(
     #    "POST",
     #    "/presignedUrls",
     #    headers=headers,
     #    json=presigned_url_body,
-    #)
+    # )
 
     # uncomment below to assert the status code of the HTTP response
-    #assert response.status_code == 200
-
+    # assert response.status_code == 200

--- a/backend/api/tests/test_service_token_api.py
+++ b/backend/api/tests/test_service_token_api.py
@@ -18,12 +18,11 @@ def test_create_new_service_token(client: TestClient):
         "Authorization": "Bearer special-key",
     }
     # uncomment below to make a request
-    #response = client.request(
+    # response = client.request(
     #    "POST",
     #    "/token",
     #    headers=headers,
-    #)
+    # )
 
     # uncomment below to assert the status code of the HTTP response
-    #assert response.status_code == 200
-
+    # assert response.status_code == 200


### PR DESCRIPTION
`/token` endpoint now also accepts SciCat user tokens. The validatior invokes the `/api/v3/users/my/identity` of SciCat API and checks whether the user has the `ingestor` group assigned. If everything is okay, it generates a new Keycloak-signed ingestor JWT token.