### PR TITLE
TraefiK: add a route to proxy minio on port 443

### DIFF
--- a/.env.prod
+++ b/.env.prod
@@ -32,7 +32,7 @@ API_ROOT_PATH=/archiver/api/v1
 #### Minio
 MINIO_REGION="eu-west-1"
 MINIO_ENDPOINT="scopem-openemdata.ethz.ch:9090"
-MINIO_EXTERNAL_ENDPOINT="scopem-openemdata.ethz.ch:9090"
+MINIO_EXTERNAL_ENDPOINT=scopem-openem.ethz.ch
 
 #### PREFECT
 # Prefect version used in all images

--- a/traefik.docker-compose.yml
+++ b/traefik.docker-compose.yml
@@ -75,6 +75,21 @@ configs:
             defaultCertificate:
               certFile: /opt/certs/cert.pem
               keyFile: /opt/certs/cert.key
+      http:
+        routers:
+          external-api-router:
+            rule: "Host(`$HOST`) && PathPrefix(`/`)"
+            entryPoints:
+              - websecure
+            tls: ""
+            service: 
+              external-api-minio
+        services:
+          external-api-minio:
+            loadBalancer:
+              servers:
+                - url: "https://${MINIO_ENDPOINT}"
+              passHostHeader: true
 secrets:
   authentik_token:
     file: ./.secrets/authentik_token


### PR DESCRIPTION
this is required for euler to connect via https and probably others too. Synology does not allow to host anything on 443 without a route. Minio API needs to work w/o a route.